### PR TITLE
fix for thread URL

### DIFF
--- a/bookmarklet.js
+++ b/bookmarklet.js
@@ -8,7 +8,7 @@
 
 (function(){
 
-    var s = window.location.toString().split('http://boards.4chan.org/b/res/')
+    var s = window.location.toString().split('http://boards.4chan.org/b/thread/')
     if(s.length!=2){
         alert("this is not a valid 4chan thread.");
         return;


### PR DESCRIPTION
4chan now formats the URL as /b/thread instead of /b/res
